### PR TITLE
applied the same breaking speed and block sounds as vanilla cake

### DIFF
--- a/src/main/java/net/greenjab/nekomasfixed/registry/registries/BlockRegistry.java
+++ b/src/main/java/net/greenjab/nekomasfixed/registry/registries/BlockRegistry.java
@@ -78,14 +78,14 @@ public class BlockRegistry {
                     .pushReaction(PushReaction.DESTROY)
     );
 
-    public static final Block SWEETBERRY_CAKE = register("sweetberry_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
-    public static final Block PAN_CAKE = register("pan_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
-    public static final Block GLOWBERRY_CAKE = register("glowberry_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
-    public static final Block APPLE_CAKE = register("apple_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
-    public static final Block VANILLA_CAKE = register("vanilla_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
-    public static final Block COOKIE_CAKE = register("cookie_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
-    public static final Block CHOCOLATE_CAKE = register("chocolate_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
-    public static final Block BEETROOT_CAKE = register("beetroot_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block SWEETBERRY_CAKE = register("sweetberry_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block PAN_CAKE = register("pan_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block GLOWBERRY_CAKE = register("glowberry_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block APPLE_CAKE = register("apple_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block VANILLA_CAKE = register("vanilla_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block COOKIE_CAKE = register("cookie_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block CHOCOLATE_CAKE = register("chocolate_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
+    public static final Block BEETROOT_CAKE = register("beetroot_cake", StackedCakeBlock::new, BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));
 
     static BlockSetType BAOBAB_BLOCKSETTYPE = BlockSetType.register(new BlockSetType("baobab"));
     static WoodType BAOBAB_WOODTYPE = WoodType.register(new WoodType("baobab", BAOBAB_BLOCKSETTYPE));


### PR DESCRIPTION
All 8 cake blocks in BlockRegistry.java changed from
`BlockBehaviour.Properties.of().lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0)`
to
`BlockBehaviour.Properties.of().strength(0.5F).sound(SoundType.WOOL).lightLevel(state -> state.getValue(StackedCakeBlock.LIT)?3:0));`
(matches vanilla cake behavior : wool sounds and no longer instamine)
